### PR TITLE
Add pinned inference requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Pinned dependencies for the inference pipeline.
+# Use the CPU-only PyTorch wheels hosted on the official download site.
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+torch==2.0.1
+torchvision==0.15.2
+numpy==1.24.4
+pillow==10.2.0
+scikit-learn==1.3.2
+joblib==1.3.2


### PR DESCRIPTION
## Summary
- add a repository-level `requirements.txt` with pinned versions for the inference dependencies
- document the CPU-only PyTorch wheel source to keep torch and torchvision installations GPU-free

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9f53c73988329abe142d9a1190b4c