### PR TITLE
Add Dockerfile for inference deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.10-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libglib2.0-0 \
+        libgl1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
+
+RUN mkdir -p models
+
+COPY inference.py ./
+COPY models/odi_rf.joblib ./models/
+
+# Pre-download any required artifacts during build time for offline inference.
+RUN python inference.py --help
+
+ENTRYPOINT ["python", "inference.py"]


### PR DESCRIPTION
## Summary
- add a Dockerfile based on python:3.10-slim with system dependencies for PyTorch and Pillow
- install Python requirements using the PyTorch CPU wheel index and stage inference assets
- prime the image by running `python inference.py --help` and set the entrypoint to run inference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9fd3c4114832991b7c8eace7301a7